### PR TITLE
add support for custom tokenize patterns and case-sensitive search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+# 2.4.0
+Added support for custom tokenize patterns and case-sensitive searches (supported in `js-worker-search` version 1.1.3). Usage is similar to index mode: To override the defaults (tokenize on whitespace only and case-insensitive), pass a configured `SearchApi` argument to the `reduxSearch` middleware, like so:
+
+```js
+import { reduxSearch, SearchApi } from 'redux-search'
+
+const finalCreateStore = compose(
+  // Other middleware ...
+  reduxSearch({
+    resourceIndexes: { ... },
+    resourceSelector: (resourceName, state) => state.resources.get(resourceName),
+    searchApi: new SearchApi({
+      // split on all non-alphanumeric characters,
+      // so this/that gets split to ['this','that'], for example
+      tokenizePattern: /[^a-z0-9]+/,
+      // make the search case-sensitive
+      caseSensitive: true
+    })
+  })
+)(createStore)
+```
+
 # 2.3.2
 Builds updated to depend on Babel's `babel-runtime` rather than referencing global `babelHelpers`.
 Added `module` attribute to `package.json` to point Webpack 2 towards ES module dist.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ const finalCreateStore = compose(
 )(createStore)
 ```
 
+#### Custom word boundaries (tokenization) and case-sensitivity
+
+You can also pass parameters to the SearchApi constructor that customize the way the
+search splits up the text into words (tokenizes) and change the search from the default
+case-insensitive to case-sensitive:
+
+```js
+import { reduxSearch, SearchApi } from 'redux-search'
+
+const finalCreateStore = compose(
+  // Other middleware ...
+  reduxSearch({
+    resourceIndexes: { ... },
+    resourceSelector: (resourceName, state) => state.resources.get(resourceName),
+    searchApi: new SearchApi({
+      // split on all non-alphanumeric characters,
+      // so this/that gets split to ['this','that'], for example
+      tokenizePattern: /[^a-z0-9]+/,
+      // make the search case-sensitive
+      caseSensitive: true
+    })
+  })
+)(createStore)
+```
+
 #### Connecting a Component
 
 redux-search provides selectors and action-creators for easily connecting components with the search state. For example, using `reselect` you might connect your component like so:

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "js-worker-search": "../js-worker-search",
+    "js-worker-search": "^1.1.3",
     "redux": "^3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-search",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Redux bindings for client-side search",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "js-worker-search": "^1.1.0",
+    "js-worker-search": "../js-worker-search",
     "redux": "^3.0.4"
   }
 }

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -10,8 +10,10 @@ export default class SubscribableSearchApi {
   /**
    * Constructor.
    */
-  constructor ({ indexMode } = {}) {
+  constructor ({ indexMode, tokenizePattern, caseSensitive } = {}) {
     this._indexMode = indexMode
+    this._tokenizePattern = tokenizePattern
+    this._caseSensitive = caseSensitive
     this._resourceToSearchMap = {}
 
     // Subscribers
@@ -59,8 +61,11 @@ export default class SubscribableSearchApi {
    */
   indexResource ({ fieldNamesOrIndexFunction, resourceName, resources, state }) {
     const search = new Search({
-      indexMode: this._indexMode
+      indexMode: this._indexMode,
+      tokenizePattern: this._tokenizePattern,
+      caseSensitive: this._caseSensitive
     })
+    console.log('aftersearch')
 
     if (Array.isArray(fieldNamesOrIndexFunction)) {
       if (resources.forEach instanceof Function) {

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -65,7 +65,6 @@ export default class SubscribableSearchApi {
       tokenizePattern: this._tokenizePattern,
       caseSensitive: this._caseSensitive
     })
-    console.log('aftersearch')
 
     if (Array.isArray(fieldNamesOrIndexFunction)) {
       if (resources.forEach instanceof Function) {

--- a/source/SearchApi.test.js
+++ b/source/SearchApi.test.js
@@ -10,7 +10,6 @@ function getSearchApi ({ indexMode, tokenizePattern, caseSensitive } = {}) {
 
   // Single-threaded Search API for easier testing
   const searchApi = new SearchApi({ indexMode, tokenizePattern, caseSensitive })
-  console.log('beforeindex')
   searchApi.indexResource({
     fieldNamesOrIndexFunction: ['name', 'description'],
     resourceName: 'documents',
@@ -23,7 +22,6 @@ function getSearchApi ({ indexMode, tokenizePattern, caseSensitive } = {}) {
 
 /** Simple smoke test of non-web-worker based SearchApi */
 test('SearchApi should return documents ids for any searchable field matching a query', async t => {
-  console.log('before searchapi')
   const searchApi = getSearchApi()
   const ids = await searchApi.performSearch('documents', 'One')
   t.equal(ids.length, 1)


### PR DESCRIPTION
This passes through support for tokenize patterns and case-sensitive search to js-worker-search.
This depends on [js-worker-search/PR#9](https://github.com/bvaughn/js-worker-search/pull/9) being merged and released as 1.1.3.