### PR TITLE
Terminating worker if a search api exists for given resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "js-worker-search": "^1.2.0",
+    "js-worker-search": "^1.3.0",
     "redux": "^3.0.4"
   }
 }

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -60,6 +60,11 @@ export default class SubscribableSearchApi {
    * @param state State object to be passed to custom resource-indexing functions
    */
   indexResource ({ fieldNamesOrIndexFunction, resourceName, resources, state }) {
+    // Terminate worker in existing SearchAPI instance
+    if (this._resourceToSearchMap[resourceName]) {
+      this._resourceToSearchMap[resourceName].terminate()
+    }
+
     const search = new Search({
       indexMode: this._indexMode,
       tokenizePattern: this._tokenizePattern,

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -60,9 +60,12 @@ export default class SubscribableSearchApi {
    * @param state State object to be passed to custom resource-indexing functions
    */
   indexResource ({ fieldNamesOrIndexFunction, resourceName, resources, state }) {
-    // Terminate worker in existing SearchAPI instance
-    if (this._resourceToSearchMap[resourceName]) {
-      this._resourceToSearchMap[resourceName].terminate()
+    // If this resource has already been indexed,
+    // Terminate the web worker before re-indexing.
+    // This prevents a memory leak (see issue #70).
+    const previousSearch = this._resourceToSearchMap[resourceName];
+    if (previousSearch !== undefined) {
+      previousSearch.terminate()
     }
 
     const search = new Search({


### PR DESCRIPTION
Code added to terminate workers to prevent memory leaks. Fixes [issue 70](https://github.com/bvaughn/redux-search/issues/70)