### PR TITLE
Add support for matching on any search token

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ const finalCreateStore = compose(
 )(createStore)
 ```
 
-#### Custom word boundaries (tokenization) and case-sensitivity
+#### Custom word boundaries (tokenization), case-sensitivity and partial token matching
 
-You can also pass parameters to the SearchApi constructor that customize the way the
-search splits up the text into words (tokenizes) and change the search from the default
-case-insensitive to case-sensitive:
+You can also pass parameters to the SearchApi constructor that customize the
+way the search splits up the text into words (tokenizes), change the search
+from the default case-insensitive to case-sensitive and/or enable matching on
+any search token (changing the search filtering from AND to OR):
 
 ```js
 import { reduxSearch, SearchApi } from 'redux-search'
@@ -124,6 +125,9 @@ const finalCreateStore = compose(
       tokenizePattern: /[^a-z0-9]+/,
       // make the search case-sensitive
       caseSensitive: true
+      // make the search match any search token. The results will be sorted by
+      // the number of matching tokens in descending order.
+      matchAnyToken: true
     })
   })
 )(createStore)

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "js-worker-search": "^1.3.0",
+    "js-worker-search": "^1.4.0",
     "redux": "^3.0.4"
   }
 }

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -10,10 +10,11 @@ export default class SubscribableSearchApi {
   /**
    * Constructor.
    */
-  constructor ({ indexMode, tokenizePattern, caseSensitive } = {}) {
+  constructor ({ indexMode, tokenizePattern, caseSensitive, matchAnyToken } = {}) {
     this._indexMode = indexMode
     this._tokenizePattern = tokenizePattern
     this._caseSensitive = caseSensitive
+    this._matchAnyToken = matchAnyToken
     this._resourceToSearchMap = {}
 
     // Subscribers
@@ -71,7 +72,8 @@ export default class SubscribableSearchApi {
     const search = new Search({
       indexMode: this._indexMode,
       tokenizePattern: this._tokenizePattern,
-      caseSensitive: this._caseSensitive
+      caseSensitive: this._caseSensitive,
+      matchAnyToken: this._matchAnyToken
     })
 
     if (Array.isArray(fieldNamesOrIndexFunction)) {

--- a/source/SearchApi.test.js
+++ b/source/SearchApi.test.js
@@ -2,14 +2,14 @@ import test from 'tape'
 import { INDEX_MODES } from 'js-worker-search'
 import SearchApi from './SearchApi'
 
-function getSearchApi ({ indexMode, tokenizePattern, caseSensitive } = {}) {
+function getSearchApi ({ indexMode, tokenizePattern, caseSensitive, matchAnyToken } = {}) {
   const documentA = {id: 1, name: 'One', description: 'The first document'}
   const documentB = {id: 2, name: 'Two', description: 'The second document'}
   const documentC = {id: 3, name: 'Three', description: 'The third document'}
   const documentD = {id: 4, name: 'Four', description: 'The 4th (fourth) document'}
 
   // Single-threaded Search API for easier testing
-  const searchApi = new SearchApi({ indexMode, tokenizePattern, caseSensitive })
+  const searchApi = new SearchApi({ indexMode, tokenizePattern, caseSensitive, matchAnyToken })
   searchApi.indexResource({
     fieldNamesOrIndexFunction: ['name', 'description'],
     resourceName: 'documents',
@@ -91,6 +91,19 @@ test('SearchApi should pass through the correct :caseSensitive bit', async t => 
   matches = await searchApi.performSearch('documents', 'second')
   t.equal(matches.length, 1)
   t.equal(matches[0], 2)
+
+  t.end()
+})
+
+test('SearchApi should pass through the correct :matchAnyToken bit', async t => {
+  const searchApi = getSearchApi({
+    matchAnyToken: true
+  })
+
+  const matches = await searchApi.performSearch('documents', 'first two second')
+  t.equal(matches.length, 2)
+  t.equal(matches[0], 2) // Second document has more matching tokens
+  t.equal(matches[1], 1)
 
   t.end()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,9 +3049,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-worker-search@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/js-worker-search/-/js-worker-search-1.3.0.tgz#c3738fbb0699cddbde0c517dcfb81fc834f52d27"
+js-worker-search@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/js-worker-search/-/js-worker-search-1.4.0.tgz#504f06cca63591be743a5e9a52e3544cb09ac7d4"
+  integrity sha512-xhRydfK5+/wBifybewZQQSG/2YWp/jghKiUJxyrMcoRsy3bhoeRY6cJH6FajqQAlaDLqnTYXkTK8TH15qNTsuw==
   dependencies:
     flow-bin "^0.50.0"
     uuid "^2.0.1"


### PR DESCRIPTION
This PR adds support for search queries that can match on any search token, i.e. OR queries.

Search support for this feature was added in https://github.com/bvaughn/js-worker-search/pull/19 (version 1.4.0)

---

@bvaughn  Thanks again for the quick response in `js-worker-search`. Hoping that this PR fulfills the need to implement the feature as well. Thanks!