### PR TITLE
Add an option to make search on index update optional

### DIFF
--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -10,11 +10,12 @@ export default class SubscribableSearchApi {
   /**
    * Constructor.
    */
-  constructor ({ caseSensitive, indexMode, matchAnyToken, tokenizePattern } = {}) {
+  constructor ({ caseSensitive, indexMode, matchAnyToken, tokenizePattern, searchOnIndexUpdate } = { searchOnIndexUpdate: true }) {
     this._caseSensitive = caseSensitive
     this._indexMode = indexMode
     this._matchAnyToken = matchAnyToken
     this._tokenizePattern = tokenizePattern
+    this.searchOnIndexUpdate = searchOnIndexUpdate
 
     this._resourceToSearchMap = {}
 

--- a/source/SearchApi.js
+++ b/source/SearchApi.js
@@ -10,7 +10,7 @@ export default class SubscribableSearchApi {
   /**
    * Constructor.
    */
-  constructor ({ caseSensitive, indexMode, matchAnyToken, tokenizePattern, searchOnIndexUpdate } = { searchOnIndexUpdate: true }) {
+  constructor ({ caseSensitive, indexMode, matchAnyToken, searchOnIndexUpdate, tokenizePattern } = { searchOnIndexUpdate: true }) {
     this._caseSensitive = caseSensitive
     this._indexMode = indexMode
     this._matchAnyToken = matchAnyToken

--- a/source/reduxSearch.js
+++ b/source/reduxSearch.js
@@ -77,7 +77,9 @@ export default function reduxSearch ({
               resources: resource,
               state: nextState
             }))
-            store.dispatch(actions.search(resourceName)(searchString))
+            if (searchApi.searchOnIndexUpdate) {
+              store.dispatch(actions.search(resourceName)(searchString))
+            }
           }
         }
       })

--- a/source/reduxSearch.test.js
+++ b/source/reduxSearch.test.js
@@ -82,7 +82,7 @@ test('reduxSearch should auto-index searchable resources if a resourceSelector i
   // Simulate a resource update
   store.dispatch({ type: 'fakeResourceUpdate' })
 
-  // Called once on resource-change and once after search has been re-run
+  // Called once on resource-change
   t.equal(resourceSelectorCalls.length, 1)
   t.equal(resourceSelectorCalls[0].resourceName, 'users')
   t.equal(searchApi.indexResourceCalls.length, 1)


### PR DESCRIPTION
**Motivation**

The current behaviour of `redux-search` is to dispatch a `search` action every time the document is updated. This is desirable if you have a single, monolithic index of documents when you set up your search machinery. However, in some cases, you might want to "hot swap" indexable content (i.e. if you are switching view from one document to another, fetching content in the process) but not initiate a search until the user intentionally does so.

In the latter case, the automatic search on update is redundant and produces unnecessary work. Even if said work is done through a worker and not on the main thread, unnecessary work that can be avoided is always problematic.

**Description**

This PR adds an optional `searchOnIndexUpdate` option to the `SearchApi` object that allows the consumer to decide whether a search should be initiated when the index is updated. By default, this option is set to `true` to preserve previous behaviour, but if set to `false`, the `search` action is not dispatched following an index update, decoupling the two.

**To Do**
- [ ] Add documentation*

* I would love some guidance on how to properly document this as per the project's style / existing patterns.